### PR TITLE
Feature/courseinfoscreen

### DIFF
--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -8,7 +8,7 @@ import { useRouter } from 'vue-router'
 import { classrooms } from '../utils/locations.js'
 
 const router = useRouter()
-const props = defineProps(['pieces', 'whole'])
+const props = defineProps(['pieces', 'whole', 'quarter'])
 const ds = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 const colors = [
@@ -86,6 +86,17 @@ const locate = location => {
   if (classrooms[location]) router.push('/map?q=' + location)
 }
 
+// Class to courseInfo redirect
+const courseInfo = (courseId, quarter) => {
+  if (courseId) 
+  router.push({
+    path: '/course',
+    query: {
+      courseId,
+      quarter
+    }})
+}
+
 setInterval(() => { date = new Date() }, 60e3)
 document.onvisibilitychange = () => { date = new Date() }
 </script>
@@ -116,7 +127,7 @@ document.onvisibilitychange = () => { date = new Date() }
           <div v-for="j in 112" class="all-transition bg-gray-100 hover:bg-gray-50 rounded" />
           <template v-for="p in props.pieces">
             <div v-if="!isHide(p)" :style="pStyle(p)"
-                class="all-transition absolute p-1 text-xs rounded-r-sm overflow-hidden"
+                class="all-transition absolute p-1 text-xs rounded-r-sm overflow-hidden z-20"
                 :class="classrooms[p.location] ? 'group' : 'group'">
 
               <div
@@ -124,18 +135,20 @@ document.onvisibilitychange = () => { date = new Date() }
                   absolute
                   right-1
                   top-auto bottom-1
-                  sm:top-1 sm:bottom-auto
-                  flex flex-col gap-1 sm:flex-row sm:items-center
+                  xl:top-1 xl:bottom-auto
+                  flex flex-col gap-1
+                  xl:flex-row xl:items-center
                 "
               >
                 <BookOpenIcon
+                  @click.stop="courseInfo(p.key, props.quarter)"
                   :class="colorMap[p.key][1]"
                   class="
                     w-[clamp(14px,4vw,20px)]
                     h-[clamp(14px,4vw,20px)]
                     opacity-0 group-hover:opacity-100
                     hover:opacity-70
-                    transition-opacity cursor-pointer
+                    z-30 transition-opacity cursor-pointer
                   "
                 />
                 <MapPinIcon
@@ -147,7 +160,7 @@ document.onvisibilitychange = () => { date = new Date() }
                     h-[clamp(14px,4vw,20px)]
                     opacity-0 group-hover:opacity-100
                     hover:opacity-70
-                    transition-opacity cursor-pointer
+                    z-30 transition-opacity cursor-pointer
                   "
                 />
               </div>

--- a/src/views/Class.vue
+++ b/src/views/Class.vue
@@ -171,7 +171,7 @@ function removeCustom (i) {
     </div>
     <div class="w-full flex flex-wrap justify-center items-start" v-if="data" :key="q">
       <div class="flex-grow bg-white sm:p-2 sm:pb-4 lg:px-6 pb-4 rounded shadow m-0 sm:m-4 lg:mr-0" v-if="data.schedule"><!-- schedule -->
-        <Schedule :pieces="pieces" whole="1" />
+        <Schedule :pieces="pieces" :quarter='q' whole="1" />
       </div>
       <div class="m-2 w-full lg:w-72 xl:w-80"><!-- side -->
         <div :show="1" v-if="data.schedule" class="p-2">

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -10,8 +10,9 @@ import Course from '../components/Course.vue'
 import Wrapper from '../components/Wrapper.vue'
 import PanelWrapper from '../components/PanelWrapper.vue'
 import LabelSwitch from '../components/LabelSwitch.vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 const router = useRouter()
+const route = useRoute()
 log('web/course')
 
 let loading = $ref(true), list = $ref(null), hideList = $ref({}), showSub = $ref({}), subjects = $ref([])
@@ -60,11 +61,24 @@ get('cache/quarter').then(data => {
   else state.course.quarter = quarters[0]
 })
 
-watch(() => state.course.quarter, v => {
-  focus = false
-  state.course.focus = cache.get('course' + v) || {}
-  fetchList()
-})
+watch(
+  () => route.query.courseId,
+  v => {
+    focus = v || ''
+  },
+  { immediate: true }
+)
+
+watch(
+  () => state.course.quarter,
+  (v, old) => {
+    if (!route.query.quarter || v !== route.query.quarter) {
+      focus = ''
+    }
+    state.course.focus = cache.get('course' + v) || {}
+    fetchList()
+  }
+)
 
 watch(() => state.course.focus, v => {
   const res = {}
@@ -73,6 +87,15 @@ watch(() => state.course.focus, v => {
   }
   cache.set('course' + state.course.quarter, res)
 }, { deep: true })
+
+watch(() => route.query.quarter, v => {
+  if (typeof v === 'string' && v !== state.course.quarter){
+    state.course.quarter=v
+  }
+},
+{immediate: true}
+)
+
 </script>
 
 <template>
@@ -119,7 +142,8 @@ watch(() => state.course.focus, v => {
           </PanelWrapper>
         </template>
       </div>
-      <Course v-model="focus" />
+      <Course v-model="focus"
+      :quarter="state.course.quarter"/>
     </div>
   </div>
 </template>


### PR DESCRIPTION
closes #16 
* Fixed issue where clicking the entire course box would redirect to the map, made it only when user clicks map icon.
* Added a clearly accessible icon in the course box to open the corresponding course information page.
* Implemented redirect logic that passes both the course ID and the specific quarter the class was taken.
* Ensures that users see the correct course data for the selected quarter rather than defaulting to the current term.